### PR TITLE
Propagate conda environment throughout pipeline.

### DIFF
--- a/R/MAIN.R
+++ b/R/MAIN.R
@@ -470,6 +470,7 @@ finemap_pipeline <- function(locus,
                                   QTL_prefixes=QTL_prefixes,
 
                                   remove_tmps = remove_tmps,
+                                  conda_env = conda_env,
                                   verbose = verbose)
   #### Extract LD ####
   LD_list <- LD.load_or_create(locus_dir=locus_dir,

--- a/R/query.R
+++ b/R/query.R
@@ -243,6 +243,7 @@ extract_SNP_subset <- function(locus=NULL,
                                probe_path = "./Data/eQTL/gene.ILMN.map",
                                QTL_prefixes=NULL,
                                remove_tmps=T,
+                               conda_env = "echoR",
                                verbose=T){
   if(is.null(locus)) locus <- basename(locus_dir)
   multi_path <- create_method_path(locus_dir = locus_dir,
@@ -277,6 +278,7 @@ extract_SNP_subset <- function(locus=NULL,
                   bp_distance=bp_distance,
                   query_by=query_by,
                   probe_path=probe_path,
+                  conda_env = conda_env,
                   verbose=verbose)
     # Clean file
     query <- standardize_subset(locus=locus,


### PR DESCRIPTION
Thanks for the great package. I was running the example `finemap_loci()` command in the full pipeline vignette with a conda environment with a different name (I passed it via `conda_env`). I was getting messages about tools not being found in "echoR" even though I wasn't using that conda environment, e.g.

```
[1] "+ CONDA:: 'echoR' conda environment not found. Using default 'python' instead."
[1] "CONDA:: Could not identify bgzip executable in echoR env. Defaulting to generic 'bgzip' command"
[1] "CONDA:: Could not identify tabix executable in echoR env. Defaulting to generic 'tabix' command"
```

This PR updates the internal function calls made by `finemap_loci()` so that the same conda environment is always used. At least for me, this removed all the messages about missing executables.