### PR TITLE
Reduce conda channels to solve environment faster

### DIFF
--- a/inst/conda/echoR.yml
+++ b/inst/conda/echoR.yml
@@ -1,10 +1,8 @@
 name: echoR
 channels:
-  - defaults
-  - bioconda
-  - biobuilds
   - conda-forge
-  - anaconda
+  - bioconda
+  - nodefaults
 dependencies:
   # Python
   - python>=3.6.1


### PR DESCRIPTION
A common strategy for reducing the time it takes to install a conda environment is to reduce the number of channels that the solver has to consider. I was able to install all of the dependencies in the echoR conda environment using only the conda-forge and bioconda channels. Specifying ["nodefaults"](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html) removes the defaults channel.

Here's the resulting environment I got from running `conda env create -f inst/conda/echoR.yml`

<details>
<summary>
<code>conda list -n echoR</code>
</summary>

```
# packages in environment at **/mambaforge/envs/echoR:
#
# Name                    Version                   Build  Channel
_libgcc_mutex             0.1                 conda_forge    conda-forge
_openmp_mutex             4.5                       1_gnu    conda-forge
_r-mutex                  1.0.1               anacondar_1    conda-forge
abseil-cpp                20200923.3           h9c3ff4c_0    conda-forge
arrow-cpp                 3.0.0           py38h6da0e5f_9_cpu    conda-forge
aws-c-cal                 0.4.5                h76129ab_8    conda-forge
aws-c-common              0.5.2                h7f98852_0    conda-forge
aws-c-event-stream        0.2.7                h6bac3ce_1    conda-forge
aws-c-io                  0.9.1                ha5b09cb_1    conda-forge
aws-checksums             0.1.11               h99e32c3_3    conda-forge
aws-sdk-cpp               1.8.151              hceb1b1e_1    conda-forge
axel                      2.17.10              h9b69904_0    conda-forge
bcftools                  1.12                 h3f113a9_0    bioconda
binutils_impl_linux-64    2.35.1               h193b22a_2    conda-forge
binutils_linux-64         2.35                h67ddf6f_30    conda-forge
bioconductor-annotationdbi 1.52.0                    r40_0    bioconda
bioconductor-annotationfilter 1.14.0                    r40_0    bioconda
bioconductor-biobase      2.50.0            r40h037d062_0    bioconda
bioconductor-biocfilecache 1.14.0                    r40_0    bioconda
bioconductor-biocgenerics 0.36.0                    r40_0    bioconda
bioconductor-biocparallel 1.24.0            r40h5f743cb_0    bioconda
bioconductor-biomart      2.46.0                    r40_0    bioconda
bioconductor-biostrings   2.58.0            r40h037d062_0    bioconda
bioconductor-biovizbase   1.38.0            r40h037d062_0    bioconda
bioconductor-bsgenome     1.58.0                    r40_0    bioconda
bioconductor-delayedarray 0.16.0            r40h037d062_0    bioconda
bioconductor-ensdb.hsapiens.v75 2.99.0                    r40_8    bioconda
bioconductor-ensembldb    2.14.0                    r40_0    bioconda
bioconductor-genomeinfodb 1.26.0                    r40_0    bioconda
bioconductor-genomeinfodbdata 1.2.4                     r40_0    bioconda
bioconductor-genomicalignments 1.26.0            r40h037d062_0    bioconda
bioconductor-genomicfeatures 1.42.0                    r40_0    bioconda
bioconductor-genomicranges 1.42.0            r40h037d062_0    bioconda
bioconductor-ggbio        1.38.0                    r40_0    bioconda
bioconductor-graph        1.68.0            r40h037d062_0    bioconda
bioconductor-iranges      2.24.0            r40h037d062_0    bioconda
bioconductor-matrixgenerics 1.2.0                     r40_0    bioconda
bioconductor-organismdbi  1.32.0                    r40_0    bioconda
bioconductor-protgenerics 1.22.0                    r40_0    bioconda
bioconductor-rbgl         1.66.0            r40h5f743cb_0    bioconda
bioconductor-rgraphviz    2.34.0            r40h5f743cb_0    bioconda
bioconductor-rhtslib      1.22.0            r40h037d062_0    bioconda
bioconductor-rsamtools    2.6.0             r40h5f743cb_0    bioconda
bioconductor-rtracklayer  1.50.0            r40h9bb0e53_1    bioconda
bioconductor-s4vectors    0.28.0            r40h037d062_0    bioconda
bioconductor-snpstats     1.40.0            r40h037d062_0    bioconda
bioconductor-summarizedexperiment 1.20.0                    r40_0    bioconda
bioconductor-suprahex     1.28.0                    r40_0    bioconda
bioconductor-variantannotation 1.36.0            r40h037d062_0    bioconda
bioconductor-xvector      0.30.0            r40h037d062_0    bioconda
bioconductor-zlibbioc     1.36.0            r40h037d062_0    bioconda
bitarray                  1.8.0            py38h497a2fe_0    conda-forge
brotli                    1.0.9                h9c3ff4c_4    conda-forge
brotlipy                  0.7.0           py38h497a2fe_1001    conda-forge
bwidget                   1.9.14               ha770c72_0    conda-forge
bzip2                     1.0.8                h7f98852_4    conda-forge
c-ares                    1.17.1               h7f98852_1    conda-forge
ca-certificates           2020.12.5            ha878542_0    conda-forge
cairo                     1.16.0            h6cf1ce9_1008    conda-forge
certifi                   2020.12.5        py38h578d9bd_1    conda-forge
cffi                      1.14.5           py38ha65f79e_0    conda-forge
chardet                   4.0.0            py38h578d9bd_1    conda-forge
cryptography              3.4.6            py38ha5dfef3_0    conda-forge
curl                      7.75.0               h979ede3_0    conda-forge
decorator                 4.4.2                      py_0    conda-forge
fastparquet               0.5.0            py38h5c078b8_0    conda-forge
fontconfig                2.13.1            hba837de_1004    conda-forge
freetype                  2.10.4               h0708190_1    conda-forge
fribidi                   1.0.10               h36c2ea0_0    conda-forge
gcc_impl_linux-64         9.3.0               h70c0ae5_18    conda-forge
gcc_linux-64              9.3.0               hf25ea35_30    conda-forge
gettext                   0.19.8.1          h0b5b191_1005    conda-forge
gflags                    2.2.2             he1b5a44_1004    conda-forge
gfortran_impl_linux-64    9.3.0               hc4a2995_18    conda-forge
gfortran_linux-64         9.3.0               hdc58fab_30    conda-forge
glog                      0.4.0                h49b9bf7_3    conda-forge
gmp                       6.2.1                h58526e2_0    conda-forge
graphite2                 1.3.13            h58526e2_1001    conda-forge
grpc-cpp                  1.36.4               h7919d58_0    conda-forge
gsl                       2.6                  he838d99_2    conda-forge
gxx_impl_linux-64         9.3.0               hd87eabc_18    conda-forge
gxx_linux-64              9.3.0               h3fbe746_30    conda-forge
harfbuzz                  2.8.0                h83ec7ef_1    conda-forge
htslib                    1.12                 hd3b49d5_0    bioconda
icu                       68.1                 h58526e2_0    conda-forge
idna                      2.10               pyh9f0ad1d_0    conda-forge
jinja2                    2.11.3             pyh44b312d_0    conda-forge
joblib                    1.0.1              pyhd8ed1ab_0    conda-forge
jpeg                      9d                   h36c2ea0_0    conda-forge
kernel-headers_linux-64   2.6.32              h77966d4_13    conda-forge
krb5                      1.17.2               h926e7f8_0    conda-forge
ld_impl_linux-64          2.35.1               hea4e1c9_2    conda-forge
libblas                   3.8.0               17_openblas    conda-forge
libcblas                  3.8.0               17_openblas    conda-forge
libcurl                   7.75.0               hc4aaa36_0    conda-forge
libdeflate                1.7                  h7f98852_5    conda-forge
libedit                   3.1.20191231         he28a2e2_2    conda-forge
libev                     4.33                 h516909a_1    conda-forge
libevent                  2.1.10               hcdb4288_3    conda-forge
libffi                    3.3                  h58526e2_2    conda-forge
libgcc-devel_linux-64     9.3.0               h7864c58_18    conda-forge
libgcc-ng                 9.3.0               h2828fa1_18    conda-forge
libgfortran-ng            9.3.0               hff62375_18    conda-forge
libgfortran5              9.3.0               hff62375_18    conda-forge
libgit2                   1.1.0                h3974521_1    conda-forge
libglib                   2.68.0               h3e27bee_1    conda-forge
libgomp                   9.3.0               h2828fa1_18    conda-forge
libiconv                  1.16                 h516909a_0    conda-forge
libidn2                   2.3.0                h516909a_0    conda-forge
liblapack                 3.8.0               17_openblas    conda-forge
libllvm10                 10.0.1               he513fc3_3    conda-forge
libnghttp2                1.43.0               h812cca2_0    conda-forge
libopenblas               0.3.10          pthreads_h4812303_5    conda-forge
libpng                    1.6.37               h21135ba_2    conda-forge
libprotobuf               3.15.6               h780b84a_0    conda-forge
libssh2                   1.9.0                ha56f1ee_6    conda-forge
libstdcxx-devel_linux-64  9.3.0               hb016644_18    conda-forge
libstdcxx-ng              9.3.0               h6de172a_18    conda-forge
libthrift                 0.14.1               he6d91bd_1    conda-forge
libtiff                   4.2.0                hdc55705_0    conda-forge
libunistring              0.9.10               h14c3975_0    conda-forge
libutf8proc               2.6.1                h7f98852_0    conda-forge
libuuid                   2.32.1            h7f98852_1000    conda-forge
libwebp-base              1.2.0                h7f98852_2    conda-forge
libxcb                    1.13              h7f98852_1003    conda-forge
libxml2                   2.9.10               h72842e0_3    conda-forge
llvmlite                  0.36.0           py38h4630a5e_0    conda-forge
lz4-c                     1.9.3                h9c3ff4c_0    conda-forge
macs2                     2.2.7.1          py38h0213d0e_1    bioconda
make                      4.3                  hd18ef5c_1    conda-forge
markupsafe                1.1.1            py38h497a2fe_3    conda-forge
ncurses                   6.2                  h58526e2_4    conda-forge
networkx                  2.5                        py_0    conda-forge
numba                     0.53.0           py38h5e62926_1    conda-forge
numpy                     1.20.1           py38h18fd61f_0    conda-forge
openssl                   1.1.1j               h7f98852_0    conda-forge
orc                       1.6.7                heec2584_1    conda-forge
packaging                 20.9               pyh44b312d_0    conda-forge
pandas                    1.2.3            py38h51da96c_0    conda-forge
pandoc                    2.12                 h7f98852_0    conda-forge
pango                     1.42.4               h69149e4_5    conda-forge
parquet-cpp               1.5.1                         2    conda-forge
pcre                      8.44                 he1b5a44_0    conda-forge
pcre2                     10.36                h032f7d1_1    conda-forge
perl                      5.32.0               h36c2ea0_0    conda-forge
pip                       21.0.1             pyhd8ed1ab_0    conda-forge
pixman                    0.40.0               h36c2ea0_0    conda-forge
plink                     1.90b6.18            h516909a_0    bioconda
pthread-stubs             0.4               h36c2ea0_1001    conda-forge
pyarrow                   3.0.0           py38h92f0514_9_cpu    conda-forge
pycparser                 2.20               pyh9f0ad1d_2    conda-forge
pyopenssl                 20.0.1             pyhd8ed1ab_0    conda-forge
pyparsing                 2.4.7              pyh9f0ad1d_0    conda-forge
pysocks                   1.7.1            py38h578d9bd_3    conda-forge
python                    3.8.8           hffdb5ce_0_cpython    conda-forge
python-dateutil           2.8.1                      py_0    conda-forge
python_abi                3.8                      1_cp38    conda-forge
pytz                      2021.1             pyhd8ed1ab_0    conda-forge
r                         4.0                    r40_1004    conda-forge
r-acepack                 1.4.1           r40h580db52_1006    conda-forge
r-ape                     5.4_1             r40h51c796c_0    conda-forge
r-askpass                 1.1               r40hcdcec82_2    conda-forge
r-assertthat              0.2.1             r40h6115d3f_2    conda-forge
r-backports               1.2.1             r40hcfec24a_0    conda-forge
r-base                    4.0.3                h8ff2632_7    conda-forge
r-base64enc               0.1_3           r40hcdcec82_1004    conda-forge
r-bh                      1.75.0_0          r40hc72bb7e_0    conda-forge
r-biocmanager             1.30.10           r40h6115d3f_1    conda-forge
r-bit                     4.0.4             r40hcdcec82_0    conda-forge
r-bit64                   4.0.5             r40hcdcec82_0    conda-forge
r-bitops                  1.0_6           r40hcdcec82_1004    conda-forge
r-blob                    1.2.1             r40h6115d3f_1    conda-forge
r-bma                     3.18.14           r40h859d828_0    conda-forge
r-boot                    1.3_27            r40hc72bb7e_0    conda-forge
r-brew                    1.0_6           r40h6115d3f_1003    conda-forge
r-brio                    1.1.1             r40hcfec24a_0    conda-forge
r-broom                   0.7.5             r40hc72bb7e_0    conda-forge
r-cachem                  1.0.4             r40hcfec24a_0    conda-forge
r-callr                   3.5.1             r40h142f84f_0    conda-forge
r-cellranger              1.1.0           r40h6115d3f_1003    conda-forge
r-checkmate               2.0.0             r40hcdcec82_1    conda-forge
r-ckmeans.1d.dp           4.3.3             r40h0357c0b_0    conda-forge
r-class                   7.3_18            r40hcfec24a_0    conda-forge
r-cli                     2.3.1             r40hc72bb7e_0    conda-forge
r-clipr                   0.7.1             r40h142f84f_0    conda-forge
r-cluster                 2.1.1             r40h859d828_0    conda-forge
r-coda                    0.19_4            r40h142f84f_0    conda-forge
r-codetools               0.2_18            r40hc72bb7e_0    conda-forge
r-coloc                   3.1               r40h6115d3f_3    bioconda
r-colorspace              2.0_0             r40h9e2df91_0    conda-forge
r-commonmark              1.7             r40hcdcec82_1002    conda-forge
r-covr                    3.5.1             r40h0357c0b_0    conda-forge
r-cpp11                   0.2.6             r40hc72bb7e_0    conda-forge
r-crayon                  1.4.1             r40hc72bb7e_0    conda-forge
r-credentials             1.3.0             r40h6115d3f_0    conda-forge
r-crosstalk               1.1.1             r40hc72bb7e_0    conda-forge
r-curl                    4.3               r40hcdcec82_1    conda-forge
r-data.table              1.14.0            r40hcfec24a_0    conda-forge
r-dbi                     1.1.1             r40hc72bb7e_0    conda-forge
r-dbplyr                  2.1.0             r40hc72bb7e_0    conda-forge
r-deoptimr                1.0_8           r40h6115d3f_1003    conda-forge
r-deriv                   4.1.3             r40hc72bb7e_0    conda-forge
r-desc                    1.3.0             r40hc72bb7e_0    conda-forge
r-desctools               0.99.40           r40h5ee154c_0    conda-forge
r-devtools                2.3.2             r40h6115d3f_0    conda-forge
r-dichromat               2.0_0                  r40_2002    conda-forge
r-diffobj                 0.3.3             r40hcfec24a_0    conda-forge
r-digest                  0.6.27            r40h1b71b39_0    conda-forge
r-dnet                    1.1.7             r40h6115d3f_1    bioconda
r-doby                    4.6.9             r40hc72bb7e_0    conda-forge
r-dplyr                   1.0.5             r40h03ef668_0    conda-forge
r-dt                      0.17              r40hc72bb7e_0    conda-forge
r-e1071                   1.7_6             r40h03ef668_0    conda-forge
r-ellipsis                0.3.1             r40hcdcec82_0    conda-forge
r-evaluate                0.14              r40h6115d3f_2    conda-forge
r-exact                   2.1               r40h142f84f_0    conda-forge
r-expm                    0.999_6           r40h52d45c5_0    conda-forge
r-fansi                   0.4.2             r40hcfec24a_0    conda-forge
r-farver                  2.1.0             r40h03ef668_0    conda-forge
r-fastmap                 1.1.0             r40h03ef668_0    conda-forge
r-flashclust              1.01_2          r40h580db52_1006    conda-forge
r-forcats                 0.5.1             r40hc72bb7e_0    conda-forge
r-foreign                 0.8_81            r40hcfec24a_0    conda-forge
r-formatr                 1.8               r40hc72bb7e_0    conda-forge
r-formula                 1.2_4             r40h142f84f_0    conda-forge
r-fs                      1.5.0             r40h0357c0b_0    conda-forge
r-futile.logger           1.4.3           r40h6115d3f_1003    conda-forge
r-futile.options          1.0.1           r40h6115d3f_1002    conda-forge
r-gbrd                    0.4_11          r40h6115d3f_1002    conda-forge
r-generics                0.1.0             r40hc72bb7e_0    conda-forge
r-gert                    1.2.0             r40hbd84cd2_1    conda-forge
r-ggally                  2.1.1             r40hc72bb7e_0    conda-forge
r-ggnetwork               0.5.8             r40h6115d3f_1    conda-forge
r-ggplot2                 3.3.3             r40hc72bb7e_0    conda-forge
r-ggrepel                 0.9.1             r40h03ef668_0    conda-forge
r-gh                      1.2.0             r40hc72bb7e_0    conda-forge
r-git2r                   0.28.0            r40hf628c3e_0    conda-forge
r-gitcreds                0.1.1             r40hc72bb7e_0    conda-forge
r-gld                     2.6.2             r40hcdcec82_1    conda-forge
r-glue                    1.4.2             r40hcfec24a_0    conda-forge
r-gridextra               2.3             r40h6115d3f_1003    conda-forge
r-gtable                  0.3.0             r40h6115d3f_3    conda-forge
r-haven                   2.3.1             r40hde08347_0    conda-forge
r-hexbin                  1.28.2            r40h859d828_0    conda-forge
r-highr                   0.8               r40h6115d3f_2    conda-forge
r-hmisc                   4.5_0             r40h859d828_0    conda-forge
r-hms                     1.0.0             r40hc72bb7e_0    conda-forge
r-htmltable               2.1.0             r40h6115d3f_0    conda-forge
r-htmltools               0.5.1.1           r40h03ef668_0    conda-forge
r-htmlwidgets             1.5.3             r40hc72bb7e_0    conda-forge
r-httr                    1.4.2             r40h6115d3f_0    conda-forge
r-igraph                  1.2.6             r40hfbf21e4_1    conda-forge
r-ini                     0.3.1           r40h6115d3f_1003    conda-forge
r-inline                  0.3.17            r40hc72bb7e_0    conda-forge
r-isoband                 0.2.4             r40h03ef668_0    conda-forge
r-jpeg                    0.1_8.1           r40hcdcec82_1    conda-forge
r-jsonlite                1.7.2             r40hcfec24a_0    conda-forge
r-kernsmooth              2.23_18           r40h742201e_0    conda-forge
r-knitr                   1.31              r40hc72bb7e_0    conda-forge
r-labeling                0.4.2             r40h142f84f_0    conda-forge
r-lambda.r                1.2.4             r40h6115d3f_1    conda-forge
r-later                   1.1.0.1           r40h0357c0b_0    conda-forge
r-lattice                 0.20_41           r40hcfec24a_3    conda-forge
r-latticeextra            0.6_29            r40h6115d3f_1    conda-forge
r-lazyeval                0.2.2             r40hcdcec82_2    conda-forge
r-leaps                   3.1               r40h580db52_2    conda-forge
r-lifecycle               1.0.0             r40hc72bb7e_0    conda-forge
r-lme4                    1.1_26            r40h03ef668_0    conda-forge
r-lmom                    2.8               r40h580db52_2    conda-forge
r-lubridate               1.7.10            r40h03ef668_0    conda-forge
r-magrittr                2.0.1             r40hcfec24a_1    conda-forge
r-markdown                1.1               r40hcfec24a_1    conda-forge
r-mass                    7.3_53.1          r40hcfec24a_0    conda-forge
r-matrix                  1.3_2             r40he454529_0    conda-forge
r-matrixstats             0.58.0            r40hcfec24a_0    conda-forge
r-memoise                 2.0.0             r40hc72bb7e_0    conda-forge
r-mgcv                    1.8_34            r40he454529_0    conda-forge
r-mime                    0.10              r40hcfec24a_0    conda-forge
r-minqa                   1.2.4           r40h228a9c8_1006    conda-forge
r-modelr                  0.1.8             r40h6115d3f_0    conda-forge
r-munsell                 0.5.0           r40h6115d3f_1003    conda-forge
r-mvtnorm                 1.1_1             r40h580db52_1    conda-forge
r-network                 1.16.0            r40hcdcec82_1    conda-forge
r-nlme                    3.1_152           r40h859d828_0    conda-forge
r-nloptr                  1.2.2.2           r40h0357c0b_0    conda-forge
r-nnet                    7.3_15            r40hcfec24a_0    conda-forge
r-numderiv                2016.8_1.1        r40h6115d3f_3    conda-forge
r-openssl                 1.4.3             r40he5c4762_0    conda-forge
r-pbkrtest                0.5.1             r40hc72bb7e_0    conda-forge
r-pcapp                   1.9_73          r40h51c796c_1003    conda-forge
r-pillar                  1.5.1             r40hc72bb7e_0    conda-forge
r-pkgbuild                1.2.0             r40hc72bb7e_0    conda-forge
r-pkgconfig               2.0.3             r40h6115d3f_1    conda-forge
r-pkgload                 1.2.0             r40h03ef668_0    conda-forge
r-plogr                   0.2.0           r40h6115d3f_1003    conda-forge
r-plyr                    1.8.6             r40h0357c0b_1    conda-forge
r-png                     0.1_7           r40hcdcec82_1004    conda-forge
r-praise                  1.0.0           r40h6115d3f_1004    conda-forge
r-prettyunits             1.1.1             r40h6115d3f_1    conda-forge
r-processx                3.5.0             r40hcfec24a_0    conda-forge
r-progress                1.2.2             r40h6115d3f_2    conda-forge
r-promises                1.2.0.1           r40h03ef668_0    conda-forge
r-proxy                   0.4_25            r40hcfec24a_0    conda-forge
r-ps                      1.6.0             r40hcfec24a_0    conda-forge
r-purrr                   0.3.4             r40hcdcec82_1    conda-forge
r-r6                      2.5.0             r40hc72bb7e_0    conda-forge
r-rappdirs                0.3.3             r40hcfec24a_0    conda-forge
r-rbibutils               2.0               r40h9e2df91_0    conda-forge
r-rcircos                 1.2.1             r40h6115d3f_2    conda-forge
r-rcmdcheck               1.3.3             r40h6115d3f_3    conda-forge
r-rcolorbrewer            1.1_2           r40h6115d3f_1003    conda-forge
r-rcpp                    1.0.6             r40h03ef668_0    conda-forge
r-rcppeigen               0.3.3.9.1         r40h306847c_0    conda-forge
r-rcurl                   1.98_1.3          r40hcfec24a_0    conda-forge
r-rdpack                  2.1.1             r40hc72bb7e_0    conda-forge
r-readr                   1.4.0             r40h1b71b39_0    conda-forge
r-readxl                  1.3.1             r40hde08347_4    conda-forge
r-recommended             4.0                    r40_1004    conda-forge
r-refgenome               1.7.7             r40h0357c0b_2    conda-forge
r-rematch                 1.0.1           r40h6115d3f_1003    conda-forge
r-rematch2                2.1.2             r40h6115d3f_1    conda-forge
r-remotes                 2.2.0             r40h6115d3f_0    conda-forge
r-reprex                  1.0.0             r40hc72bb7e_0    conda-forge
r-reshape                 0.8.8             r40hcdcec82_2    conda-forge
r-reshape2                1.4.4             r40h0357c0b_1    conda-forge
r-reticulate              1.18              r40h03ef668_0    conda-forge
r-rex                     1.2.0             r40h6115d3f_1    conda-forge
r-rlang                   0.4.10            r40hcfec24a_0    conda-forge
r-rle                     0.9.2             r40h0eb13af_0    conda-forge
r-rmarkdown               2.7               r40hc72bb7e_0    conda-forge
r-robustbase              0.93_7            r40h52d45c5_0    conda-forge
r-rootsolve               1.8.2.1           r40h580db52_2    conda-forge
r-roxygen2                7.1.1             r40h0357c0b_0    conda-forge
r-rpart                   4.1_15            r40hcfec24a_2    conda-forge
r-rprojroot               2.0.2             r40hc72bb7e_0    conda-forge
r-rrcov                   1.5_5             r40haae7e3a_1    conda-forge
r-rsqlite                 2.2.4             r40h03ef668_0    conda-forge
r-rstudioapi              0.13              r40hc72bb7e_0    conda-forge
r-rversions               2.0.2             r40h6115d3f_0    conda-forge
r-rvest                   1.0.0             r40hc72bb7e_0    conda-forge
r-scales                  1.1.1             r40h6115d3f_0    conda-forge
r-selectr                 0.4_2             r40h6115d3f_1    conda-forge
r-sessioninfo             1.1.1           r40h6115d3f_1002    conda-forge
r-sna                     2.5               r40hcdcec82_1    conda-forge
r-snow                    0.4_3           r40h6115d3f_1002    conda-forge
r-spatial                 7.3_13            r40hcfec24a_0    conda-forge
r-speedglm                0.3_3             r40ha770c72_0    conda-forge
r-statmod                 1.4.35            r40h86c2bf4_1    conda-forge
r-statnet.common          4.4.1             r40h0eb13af_0    conda-forge
r-stringi                 1.5.3             r40hcabe038_1    conda-forge
r-stringr                 1.4.0             r40h6115d3f_2    conda-forge
r-survival                3.2_10            r40hcfec24a_0    conda-forge
r-sys                     3.4               r40hcdcec82_0    conda-forge
r-testthat                3.0.2             r40h03ef668_0    conda-forge
r-tibble                  3.1.0             r40hcfec24a_1    conda-forge
r-tidyr                   1.1.3             r40h03ef668_0    conda-forge
r-tidyselect              1.1.0             r40h6115d3f_0    conda-forge
r-tidyverse               1.3.0             r40h6115d3f_2    conda-forge
r-tinytex                 0.30              r40hc72bb7e_0    conda-forge
r-usethis                 2.0.1             r40hc72bb7e_0    conda-forge
r-utf8                    1.2.1             r40hcfec24a_0    conda-forge
r-vctrs                   0.3.6             r40hcfec24a_0    conda-forge
r-viridis                 0.5.1           r40h6115d3f_1004    conda-forge
r-viridislite             0.3.0           r40h6115d3f_1003    conda-forge
r-waldo                   0.2.5             r40hc72bb7e_0    conda-forge
r-whisker                 0.4               r40h6115d3f_1    conda-forge
r-withr                   2.4.1             r40hc72bb7e_0    conda-forge
r-xfun                    0.20              r40hcfec24a_0    conda-forge
r-xgr                     1.1.7             r40h6115d3f_1    bioconda
r-xml                     3.99_0.6          r40hcfec24a_0    conda-forge
r-xml2                    1.3.2             r40h0357c0b_1    conda-forge
r-xopen                   1.0.0           r40h6115d3f_1003    conda-forge
r-yaml                    2.2.1             r40hcfec24a_1    conda-forge
r-zeallot                 0.1.0           r40h6115d3f_1002    conda-forge
r-zip                     2.1.1             r40hcdcec82_0    conda-forge
re2                       2020.11.01           h58526e2_0    conda-forge
readline                  8.0                  he28a2e2_2    conda-forge
requests                  2.25.1             pyhd3deb0d_0    conda-forge
rpy2                      3.4.3           py38r40hb5d20a5_0    conda-forge
s2n                       1.0.0                h9b69904_0    conda-forge
scikit-learn              0.24.1           py38h658cfdd_0    conda-forge
scipy                     1.6.1            py38hb2138dd_0    conda-forge
sed                       4.8                  he412f7d_0    conda-forge
setuptools                49.6.0           py38h578d9bd_3    conda-forge
simplegeneric             0.8.1                      py_1    conda-forge
six                       1.15.0             pyh9f0ad1d_0    conda-forge
snappy                    1.1.8                he1b5a44_3    conda-forge
sqlite                    3.35.2               h74cdb3f_0    conda-forge
sysroot_linux-64          2.12                h77966d4_13    conda-forge
tabix                     0.2.6                ha92aebf_0    bioconda
threadpoolctl             2.1.0              pyh5ca1d4c_0    conda-forge
thrift                    0.11.0          py38he1b5a44_1001    conda-forge
tk                        8.6.10               h21135ba_1    conda-forge
tktable                   2.10                 hb7b940f_3    conda-forge
tqdm                      4.59.0             pyhd8ed1ab_0    conda-forge
tzlocal                   2.1                pyh9f0ad1d_0    conda-forge
urllib3                   1.26.4             pyhd8ed1ab_0    conda-forge
wget                      1.20.1               h22169c7_0    conda-forge
wheel                     0.36.2             pyhd3deb0d_0    conda-forge
xorg-kbproto              1.0.7             h7f98852_1002    conda-forge
xorg-libice               1.0.10               h7f98852_0    conda-forge
xorg-libsm                1.2.3             hd9c2040_1000    conda-forge
xorg-libx11               1.7.0                h7f98852_0    conda-forge
xorg-libxau               1.0.9                h7f98852_0    conda-forge
xorg-libxdmcp             1.1.3                h7f98852_0    conda-forge
xorg-libxext              1.3.4                h7f98852_1    conda-forge
xorg-libxrender           0.9.10            h7f98852_1003    conda-forge
xorg-libxt                1.2.1                h7f98852_2    conda-forge
xorg-renderproto          0.11.1            h7f98852_1002    conda-forge
xorg-xextproto            7.3.0             h7f98852_1002    conda-forge
xorg-xproto               7.0.31            h7f98852_1007    conda-forge
xz                        5.2.5                h516909a_1    conda-forge
zlib                      1.2.11            h516909a_1010    conda-forge
zstd                      1.4.9                ha95c52a_0    conda-forge
```

</details>